### PR TITLE
ensured new_atoms not just atoms is saved to db

### DIFF
--- a/vasp_fw/vasp_db.py
+++ b/vasp_fw/vasp_db.py
@@ -163,7 +163,7 @@ class VASPDB(FiretaskBase):
         energy = atoms.get_potential_energy() # Run vasp here
         new_atoms = read('vasprun.xml')
         self.tag_atoms(new_atoms, old_atoms, 'ase-sort.dat')
-        write_index = db.write(atoms)
+        write_index = db.write(new_atoms)
         print(f"input index {input_id} output index {write_index}")
         print("DONE!")
         os.chdir(start_cwd)


### PR DESCRIPTION
Fixed bug where original atoms object, rather than modified atoms object was saved to db. 